### PR TITLE
#41: Add line breaks in theme output in RegistryDefinitionsTest::testPreprocessProcessCascade().

### DIFF
--- a/tests/src/Kernel/RegistryDefinitionsTest.php
+++ b/tests/src/Kernel/RegistryDefinitionsTest.php
@@ -36,7 +36,9 @@ class RegistryDefinitionsTest extends AbstractThemeTest {
    * @dataProvider renderProvider
    */
   public function testPreprocessProcessCascade($hook, $render) {
-    $this->assertEquals($render, theme($hook));
+    $this->assertEquals(
+      "\n" . str_replace(',', "\n", $render),
+      "\n" . str_replace(',', "\n", theme($hook)));
   }
 
   /**


### PR DESCRIPTION
Fixes #41.

Diff will look like this, see https://travis-ci.org/drupol/registryonsteroids/jobs/353130334

```diff
3) Drupal\Tests\registryonsteroids\Kernel\RegistryDefinitionsTest::testPreprocessProcessCascade with data set #3 ('ros2__variant1', 'ros_test_theme,ros_test_prepr...iant1,')
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '
 ros_test_theme
 ros_test_preprocess_ros2
-ros_test_preprocess_ros2__variant1
 ros_theme_preprocess_ros2
-ros_theme_preprocess_ros2__variant1
 ros_test_process_ros2
-ros_test_process_ros2__variant1
 '
```