### PR TITLE
#41 ff: (test) Add assertEqualThemeRegistryEntries().

### DIFF
--- a/tests/src/Kernel/AbstractThemeTest.php
+++ b/tests/src/Kernel/AbstractThemeTest.php
@@ -26,4 +26,93 @@ abstract class AbstractThemeTest extends AbstractTest {
     drupal_flush_all_caches();
   }
 
+  /**
+   * Asserts that two theme registry entries are effectively equal.
+   *
+   * @param array $expected
+   * @param array $actual
+   */
+  public function assertEqualThemeRegistryEntries(array $expected, array $actual) {
+    $this->assertEquals(
+      self::exportRegistryEntryNormalized($expected),
+      self::exportRegistryEntryNormalized($actual));
+  }
+
+  /**
+   * Exports a theme registry entry as a PHP statement.
+   *
+   * @param array $definition
+   *
+   * @return string
+   */
+  private static function exportRegistryEntryNormalized(array $definition) {
+
+    foreach (array('preprocess functions', 'process functions') as $phase_key) {
+      if (empty($definition[$phase_key])) {
+        unset($definition[$phase_key]);
+      }
+      else {
+        $definition[$phase_key] = array_values($definition[$phase_key]);
+      }
+    }
+
+    ksort($definition);
+
+    return self::exportArray($definition);
+  }
+
+  /**
+   * Exports a mixed value as a PHP statement.
+   *
+   * Only supports what is also supported in var_export().
+   * Array keys are omitted, if they are a regular integer sequence 0..n.
+   *
+   * @param mixed $value
+   * @param string $indent
+   *
+   * @return string
+   */
+  private static function exportValue($value, $indent = '') {
+    return \is_array($value)
+      ? self::exportArray($value, $indent)
+      : var_export($value, TRUE);
+  }
+
+  /**
+   * Exports an array as a PHP statement.
+   *
+   * Only supports what is also supported in var_export().
+   * Array keys are omitted, if they are a regular integer sequence 0..n.
+   *
+   * @param array $array
+   * @param string $indent
+   *
+   * @return string
+   */
+  private static function exportArray(array $array, $indent = '') {
+
+    $indent2 = $indent . '    ';
+
+    $php = '';
+    if (array_values($array) === $array) {
+      // This array has regular "serial" keys.
+      foreach ($array as $v) {
+        $php .= "\n" . $indent2
+          . self::exportValue($v, $indent2)
+          . ',';
+      }
+    }
+    else {
+      foreach ($array as $k => $v) {
+        $php .= "\n" . $indent2
+          . var_export($k, TRUE)
+          . ' => '
+          . self::exportValue($v, $indent2)
+          . ',';
+      }
+    }
+
+    return 'array(' . $php . "\n" . $indent . ')';
+  }
+
 }

--- a/tests/src/Kernel/CoreRegistryDefinitionsTest.php
+++ b/tests/src/Kernel/CoreRegistryDefinitionsTest.php
@@ -27,7 +27,7 @@ class CoreRegistryDefinitionsTest extends AbstractThemeTest {
     $registry = theme_get_registry(TRUE);
 
     $this->assertArrayHasKey($hook, $registry);
-    $this->assertEquals($definition, $registry[$hook]);
+    $this->assertEqualThemeRegistryEntries($definition, $registry[$hook]);
   }
 
   /**

--- a/tests/src/Kernel/RegistryDefinitionsTest.php
+++ b/tests/src/Kernel/RegistryDefinitionsTest.php
@@ -27,7 +27,7 @@ class RegistryDefinitionsTest extends AbstractThemeTest {
     $registry = theme_get_registry(TRUE);
 
     $this->assertArrayHasKey($hook, $registry);
-    $this->assertEquals($definition, $registry[$hook]);
+    $this->assertEqualThemeRegistryEntries($definition, $registry[$hook]);
   }
 
   /**


### PR DESCRIPTION
See #41.

This should make more meaningful diff of registry entries that do not match the expected entry in tests.