### PR TITLE
Issue #69: Update the configuration files of Travis and Runner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,17 +10,22 @@ php:
   - 7.1
   - 7.2
 
+matrix:
+  allow_failures:
+    - php: 5.6
+
 env:
   global:
     - PATH=$PATH:/home/travis/.composer/vendor/bin:$TRAVIS_BUILD_DIR/vendor/bin
 
 install:
+  - sudo apt-get install apache2
   - composer self-update
   - composer install
 
 before_script:
   # Install apache just to have the ab command.
-  - sudo apt-get install apache2
+  - phpenv config-rm xdebug.ini
   # Set sendmail so drush doesn't throw an error during site install.
   - echo "sendmail_path=`which true`" >> `php --ini | grep "Loaded Configuration" | awk '{print $4}'`
   - run drupal:site-install

--- a/runner.yml.dist
+++ b/runner.yml.dist
@@ -19,9 +19,12 @@ drupal:
         - build
         - sites/all/modules/registryonsteroids/build
         - build/sites/all/modules/registryonsteroids/build
-      theme_default: ros_theme
+      drupal_http_request_fails: false
   post_install:
-      - ./vendor/bin/drush --root=$(pwd)/build en composer_autoloader ros_test -y
+      - ./vendor/bin/drush --root=$(pwd)/build en composer_autoloader ros_test ros_theme xautoload -y
+      - ./vendor/bin/drush --root=$(pwd)/build dis help overlay update search color dashboard dblog help path -y
+      - ./vendor/bin/drush --root=$(pwd)/build pmu help overlay update search color dashboard dblog help path -y
+      - ./vendor/bin/drush --root=$(pwd)/build vset theme_default ros_theme
       - ./vendor/bin/drush --root=$(pwd)/build cc all
   drush:
     options:

--- a/runner.yml.dist
+++ b/runner.yml.dist
@@ -21,7 +21,7 @@ drupal:
         - build/sites/all/modules/registryonsteroids/build
       drupal_http_request_fails: false
   post_install:
-      - ./vendor/bin/drush --root=$(pwd)/build en composer_autoloader ros_test ros_theme xautoload -y
+      - ./vendor/bin/drush --root=$(pwd)/build en composer_autoloader ros_theme -y
       - ./vendor/bin/drush --root=$(pwd)/build dis help overlay update search color dashboard dblog help path -y
       - ./vendor/bin/drush --root=$(pwd)/build pmu help overlay update search color dashboard dblog help path -y
       - ./vendor/bin/drush --root=$(pwd)/build vset theme_default ros_theme

--- a/tests/src/Kernel/AbstractThemeTest.php
+++ b/tests/src/Kernel/AbstractThemeTest.php
@@ -20,10 +20,7 @@ abstract class AbstractThemeTest extends AbstractTest {
     $conf['theme_debug'] = FALSE;
     $conf['theme_default'] = 'ros_theme';
 
-    module_disable(array('registryonsteroids'));
-    drupal_flush_all_caches();
-    // module_enable(array('registryonsteroids'));.
-    drupal_flush_all_caches();
+    module_enable(array('ros_test'));
   }
 
   /**


### PR DESCRIPTION
Update the configuration files of Travis to allow PHP 5.6 to fail and update Runner configuration file to improve the testing environment.

Fixes #69.