### PR TITLE
Issue #71: Move xautoload module from require to require-dev section.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,6 @@
     "issues": "https://github.com/drupol/registryonsteroids/issues",
     "source": "https://github.com/drupol/registryonsteroids"
   },
-  "require": {
-    "drupal/xautoload": "*"
-  },
   "require-dev": {
     "phpro/grumphp": "^0.12",
     "phpunit/phpunit": "^5",
@@ -35,7 +32,8 @@
     "drush/drush": "^8",
     "drupal/drupal-extension": "~3.4",
     "drupal/devel": "*",
-    "openeuropa/task-runner": "^0.4"
+    "openeuropa/task-runner": "^0.4",
+    "drupal/xautoload": "*"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
The composer.json file of registryonsteroids is require the contrib module 'xautoload' in its require section.

```
...
  "require": {
    "drupal/xautoload": "*"
  },
...
```

If xautoload had been installed using drush on your site and if you're using composer_manager, then composer_manager will try to download xautoload as well.

I think we should avoid this clash by moving xautoload in the require-dev section of the composer.json file. 